### PR TITLE
docs(readme): fix markdown heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Mozilla Science Lab's Open Data Primers!
 
-###Hello! Thanks for dropping by.
+### Hello! Thanks for dropping by.
 
 You're reading an [online handbook](https://mozillascience.github.io/open-data-primers/) of Open Data Training Primers developed by the [Mozilla Science Lab](https://science.mozilla.org/) and their community members.  
 


### PR DESCRIPTION
Hello! 👋 

I saw a little typo which made the second heading in your readme render incorrectly, so I thought I'd fix it for you.

> Github's markdown parser uses the [CommonMark spec](http://spec.commonmark.org/0.28/#atx-headings), which only recognizes headings when there's a space between the `#` and the heading text. ✨